### PR TITLE
fix(deb,rpm): declare libxdo as runtime dependency

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -42,11 +42,11 @@
     "linux": {
       "deb": {
         "desktopTemplate": "donutbrowser.desktop",
-        "depends": ["xdg-utils"]
+        "depends": ["xdg-utils", "libxdo3"]
       },
       "rpm": {
         "desktopTemplate": "donutbrowser.desktop",
-        "depends": ["xdg-utils"]
+        "depends": ["xdg-utils", "libxdo"]
       },
       "appimage": {
         "files": {


### PR DESCRIPTION
## Problem

Installing `Donut_0.22.4_amd64.deb` on Ubuntu 24.04 / Zorin OS 17 succeeds without errors, but launching the app fails silently when clicked from the desktop launcher.

Running the binary from a terminal reveals the actual cause:

```
$ /usr/bin/donutbrowser
/usr/bin/donutbrowser: error while loading shared libraries: libxdo.so.3: cannot open shared object file: No such file or directory
```

The app links against `libxdo` at runtime (loaded via `dlopen` rather than directly linked), so Tauri's auto-dependency detection misses it and the package metadata does not declare it.

## Fix

Add `libxdo3` (Debian/Ubuntu) and `libxdo` (Fedora/openSUSE) to the `bundle.linux.{deb,rpm}.depends` array in `src-tauri/tauri.conf.json`.

## Verification

Locally on Zorin OS 17 / Ubuntu 24.04 with `Donut_0.22.4_amd64.deb` already installed:

```
sudo apt install -y libxdo3
/usr/bin/donutbrowser   # launches successfully
```

After this PR, fresh installs from the `.deb` will pull `libxdo3` automatically and avoid the silent launch failure.

## Note

This PR fixes the immediate startup failure I encountered. There may be additional runtime-loaded libraries surfacing in flows I haven't exercised yet (browser launching, proxy lifecycle, profile creation). Happy to follow up if more `cannot open shared object file` errors emerge.