### PR TITLE
fix: improve macOS permission grant feedback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ### Maintenance
 
-- chore: versiom bump
+- chore: version bump
 - chore: update flake.nix for v0.24.3 [skip ci] (#383)
 
 

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -21,6 +21,17 @@
     "core:window:allow-minimize",
     "core:window:allow-toggle-maximize",
     "opener:default",
+    {
+      "identifier": "opener:allow-open-url",
+      "allow": [
+        {
+          "url": "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone"
+        },
+        {
+          "url": "x-apple.systempreferences:com.apple.preference.security?Privacy_Camera"
+        }
+      ]
+    },
     "fs:default",
     "shell:allow-execute",
     "shell:allow-kill",

--- a/src/components/settings-dialog.tsx
+++ b/src/components/settings-dialog.tsx
@@ -2,6 +2,7 @@
 
 import { invoke } from "@tauri-apps/api/core";
 import { writeText as writeClipboardText } from "@tauri-apps/plugin-clipboard-manager";
+import { openUrl } from "@tauri-apps/plugin-opener";
 import Color from "color";
 import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -368,19 +369,36 @@ export function SettingsDialog({
     async (permissionType: PermissionType) => {
       setRequestingPermission(permissionType);
       try {
-        await requestPermission(permissionType);
-        showSuccessToast(
-          t("settings.permissions.accessRequested", {
-            permission: getPermissionDisplayName(permissionType),
-          }),
+        const granted = await requestPermission(permissionType);
+        if (granted) {
+          showSuccessToast(
+            permissionType === "microphone"
+              ? t("permissionDialog.grantedToastMicrophone")
+              : t("permissionDialog.grantedToastCamera"),
+          );
+          return;
+        }
+
+        await openUrl(
+          `x-apple.systempreferences:com.apple.preference.security?${
+            permissionType === "microphone"
+              ? "Privacy_Microphone"
+              : "Privacy_Camera"
+          }`,
+        );
+        showErrorToast(
+          permissionType === "microphone"
+            ? t("permissionDialog.stillNotGrantedMicrophone")
+            : t("permissionDialog.stillNotGrantedCamera"),
         );
       } catch (error) {
         console.error("Failed to request permission:", error);
+        showErrorToast(t("permissionDialog.requestFailed"));
       } finally {
         setRequestingPermission(null);
       }
     },
-    [getPermissionDisplayName, requestPermission, t],
+    [requestPermission, t],
   );
 
   const handleSave = useCallback(async () => {

--- a/src/hooks/use-permissions.ts
+++ b/src/hooks/use-permissions.ts
@@ -21,7 +21,7 @@ const loadMacOSPermissions = async () => {
 export type PermissionType = "microphone" | "camera";
 
 interface UsePermissionsReturn {
-  requestPermission: (type: PermissionType) => Promise<void>;
+  requestPermission: (type: PermissionType) => Promise<boolean>;
   isMicrophoneAccessGranted: boolean;
   isCameraAccessGranted: boolean;
   isInitialized: boolean;
@@ -68,51 +68,44 @@ export function usePermissions(): UsePermissionsReturn {
 
   // Request permission
   const requestPermission = useCallback(
-    async (type: PermissionType): Promise<void> => {
-      if (!currentPlatform || currentPlatform !== "macos") return;
+    async (type: PermissionType): Promise<boolean> => {
+      // Non-macOS platforms do not require this permission gate.
+      if (!currentPlatform || currentPlatform !== "macos") return true;
 
       // macOS - use the permissions API
       try {
         const permissions = await loadMacOSPermissions();
-        if (!permissions) return;
+        if (!permissions) return false;
+
+        const readPermission = async () => {
+          const granted =
+            type === "microphone"
+              ? await permissions.checkMicrophonePermission()
+              : await permissions.checkCameraPermission();
+          if (type === "microphone") {
+            setIsMicrophoneAccessGranted(granted);
+          } else {
+            setIsCameraAccessGranted(granted);
+          }
+          return granted;
+        };
 
         if (type === "microphone") {
           await permissions.requestMicrophonePermission();
-
-          // Poll for permission status change
-          const pollMicPermission = async () => {
-            const granted = await permissions.checkMicrophonePermission();
-            setIsMicrophoneAccessGranted(granted);
-
-            if (!granted) {
-              setTimeout(() => {
-                void pollMicPermission();
-              }, 1000);
-            }
-          };
-
-          await pollMicPermission();
-        }
-
-        if (type === "camera") {
+        } else {
           await permissions.requestCameraPermission();
-
-          // Poll for permission status change
-          const pollCamPermission = async () => {
-            const granted = await permissions.checkCameraPermission();
-            setIsCameraAccessGranted(granted);
-
-            if (!granted) {
-              setTimeout(() => {
-                void pollCamPermission();
-              }, 1000);
-            }
-          };
-
-          await pollCamPermission();
         }
+
+        for (let attempt = 0; attempt < 8; attempt += 1) {
+          const granted = await readPermission();
+          if (granted) return true;
+          await new Promise((resolve) => setTimeout(resolve, 1000));
+        }
+
+        return readPermission();
       } catch (error) {
         console.error(`Failed to request ${type} permission on macOS:`, error);
+        return false;
       }
     },
     [currentPlatform],


### PR DESCRIPTION
## Which issue does this PR fix?

No linked issue.

This fixes the macOS permission flow when a permission request does not result in an actual grant. That can happen when the user denies or dismisses the system prompt, or when macOS no longer shows the prompt because the permission was previously denied.

In that state, the current code keeps polling until the permission becomes granted, but the Settings UI does not know whether the request actually succeeded. It shows a generic requested message and does not guide the user to the macOS Privacy & Security page where the permission must be enabled manually.

This also fixes a `CHANGELOG.md` typo (`versiom` -> `version`) that was failing the repository spell check.

## How to test

Reproduce the current issue:

1. On macOS, open System Settings -> Privacy & Security -> Microphone or Camera.
2. Make sure Donut does not have access. If Donut is already listed, disable it. If needed, reset the permission state and deny the next prompt.
3. Open Donut Settings and click `Grant` for the denied permission.
4. Deny or dismiss the macOS prompt, or use a permission that macOS no longer prompts for after a previous denial.
5. Observe that Donut shows only a generic requested message even though the permission is still denied.
6. Leave the permission denied and observe that the app continues polling in the background instead of stopping and directing the user to System Settings.

Verify this PR:

1. Repeat the same flow on this branch.
2. If macOS grants the permission, confirm Donut shows the granted toast and the permission state updates.
3. If macOS does not grant the permission, confirm Donut stops after the bounded polling window, opens the matching Privacy & Security pane, and shows the manual-enable guidance.
4. Click `Grant` repeatedly while the request is running and confirm the button remains disabled until the request finishes.

Validated locally:

- `git diff --check upstream/main`
- `cargo fmt --manifest-path src-tauri/Cargo.toml --check`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm exec biome check src/ src-tauri/capabilities/default.json`
- `python3 -m json.tool src-tauri/capabilities/default.json`
- `pnpm exec typos`

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/zhom/donutbrowser/blob/main/CONTRIBUTING.md)
- [x] Ran `pnpm format && pnpm lint && pnpm test` locally and it passes
- [x] I tested the changes myself by running the app locally
- [x] Updated translations in all locale files (if UI text changed)

## AI usage

- [x] I used AI to help write this PR
