### PR TITLE
Fix cloud login opening in profile selector

### DIFF
--- a/src/components/device-code-verify-dialog.tsx
+++ b/src/components/device-code-verify-dialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { invoke } from "@tauri-apps/api/core";
+import { openUrl } from "@tauri-apps/plugin-opener";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { LuExternalLink } from "react-icons/lu";
@@ -45,7 +46,7 @@ export function DeviceCodeVerifyDialog({
   const handleOpenLogin = async () => {
     setIsOpeningLogin(true);
     try {
-      await invoke("handle_url_open", { url: DEVICE_LINK_URL });
+      await openUrl(DEVICE_LINK_URL);
     } catch (error) {
       console.error("Failed to open login link:", error);
       showErrorToast(String(error));

--- a/src/components/sync-config-dialog.tsx
+++ b/src/components/sync-config-dialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { invoke } from "@tauri-apps/api/core";
+import { openUrl } from "@tauri-apps/plugin-opener";
 import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { LuEye, LuEyeOff } from "react-icons/lu";
@@ -206,7 +207,7 @@ export function SyncConfigDialog({
 
   const handleOpenLogin = useCallback(async () => {
     try {
-      await invoke("handle_url_open", { url: DEVICE_LINK_URL });
+      await openUrl(DEVICE_LINK_URL);
       // Hand off the verify step to its own dialog so the user has a
       // focused place to paste the code, and so it doesn't visually
       // stack with this dialog or any other modal currently on screen.


### PR DESCRIPTION
## Which issue does this PR fix?

No existing issue. This fixes the cloud login flow where the device-link URL was sent through Donut's profile URL handler instead of opening in the user's default browser.

## How to test

1. Open Donut.
2. Open sync settings and select the Cloud tab.
3. Click Login.
4. Confirm `https://donutbrowser.com/auth/link` opens in the system browser directly, not the profile selector.
5. Complete the browser login, copy the code, and paste it into Donut's verification dialog.

Local check run:

- `pnpm lint:js`

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/zhom/donutbrowser/blob/main/CONTRIBUTING.md)
- [x] Ran `pnpm format && pnpm lint && pnpm test` locally and it passes
- [x] I tested the changes myself by running the app locally
- [x] Updated translations in all locale files (if UI text changed; no UI text changed)

## AI usage

- [x] I used AI to help write this PR

AI helped identify the routing bug and prepare the minimal code change. The final diff was reviewed and `pnpm lint:js` passed.