### PR TITLE
fix Wayfern download retry handling and error logging

### DIFF
--- a/src-tauri/src/api_client.rs
+++ b/src-tauri/src/api_client.rs
@@ -1163,7 +1163,17 @@ impl ApiClient {
           }
         }
         Err(e) => {
-          log::warn!("Wayfern fetch attempt {attempt}/3 failed: {e}");
+          use std::error::Error as StdError;
+          let mut parts = vec![e.to_string()];
+          let mut source = e.source();
+          while let Some(s) = source {
+            parts.push(s.to_string());
+            source = s.source();
+          }
+          log::warn!(
+            "Wayfern fetch attempt {attempt}/3 failed: {}",
+            parts.join(": ")
+          );
           last_err = Some(e.to_string());
         }
       }
@@ -1181,11 +1191,10 @@ impl ApiClient {
     })?;
     log::info!("Fetched Wayfern version: {}", version_info.version);
 
-    // Cache the results (unless bypassing cache)
-    if !no_caching {
-      if let Err(e) = self.save_cached_wayfern_version(&version_info) {
-        log::error!("Failed to cache Wayfern version: {e}");
-      }
+    // Always persist a freshly-fetched version so subsequent calls within the
+    // same download flow can read from cache instead of hitting the network again.
+    if let Err(e) = self.save_cached_wayfern_version(&version_info) {
+      log::error!("Failed to cache Wayfern version: {e}");
     }
 
     Ok(version_info)

--- a/src-tauri/src/downloader.rs
+++ b/src-tauri/src/downloader.rs
@@ -146,10 +146,12 @@ impl Downloader {
         Ok(asset_url)
       }
       BrowserType::Wayfern => {
-        // For Wayfern, get the download URL from version.json
+        // For Wayfern, get the download URL from version.json.
+        // download_browser_full already fetched the version and wrote it to
+        // cache, so we can read from cache here to avoid a redundant request.
         let version_info = self
           .api_client
-          .fetch_wayfern_version_with_caching(true)
+          .fetch_wayfern_version_with_caching(false)
           .await?;
 
         if version_info.version != version {


### PR DESCRIPTION
Fixes #374

## What changed

**Duplicate network request eliminated**

When downloading Wayfern, the version JSON at `donutbrowser.com/wayfern.json` was being fetched twice: once in `download_browser_full` (to resolve the actual available version) and again inside `resolve_download_url` → `download_browser` (to get the platform-specific download URL). Both calls passed `no_caching=true`, so neither read nor wrote the file cache. The result was two complete retry sequences (up to 6 requests total) for every single download attempt, which is exactly what the doubled log lines in #374 show:

```
Wayfern fetch attempt 1/3 failed  <- first full retry sequence
Wayfern fetch attempt 1/3 failed  <- second, redundant sequence
```

Fix: `fetch_wayfern_version_with_caching` now always writes the result to disk cache after a successful network fetch, regardless of `no_caching`. The second call in `resolve_download_url` is changed to `no_caching=false` so it reads the value that was just cached — no extra request needed.

**Better error logging**

The retry warning previously logged `{e}` which for reqwest gives only the outer wrapper:
```
Wayfern fetch attempt 1/3 failed: error sending request for url (https://...)
```
The real cause (TLS error, DNS failure, proxy rejection, OS error) sits in the error source chain and was silently dropped. The log now walks `.source()` and joins all levels with `: `, so a certificate error would show up as:
```
Wayfern fetch attempt 1/3 failed: error sending request for url (...): error trying to connect: certificate verify failed
```
This makes it much easier to diagnose network failures without needing a debugger.

## How I tested it

- `cargo check` passes cleanly on the patched tree
- Confirmed `resolve_download_url` is only reachable via `download_browser` → `download_browser_full`, so the cache is always warm by the time the second call runs
- The `no_caching` path in `browser_version_manager` is unaffected — it passes the flag straight through unchanged