### PR TITLE
fix: reuse target-specific sidecar binaries

### DIFF
--- a/src-tauri/copy-proxy-binary.mjs
+++ b/src-tauri/copy-proxy-binary.mjs
@@ -31,7 +31,7 @@ const isWindows = TARGET.includes("windows");
 
 // Determine source directory
 let srcDir;
-if (TARGET === HOST_TARGET || TARGET === "unknown") {
+if ((!process.env.TARGET && TARGET === HOST_TARGET) || TARGET === "unknown") {
   srcDir = join(MANIFEST_DIR, "target", PROFILE === "release" ? "release" : "debug");
 } else {
   srcDir = join(MANIFEST_DIR, "target", TARGET, PROFILE === "release" ? "release" : "debug");
@@ -57,7 +57,7 @@ function copyBinary(baseName) {
 
     const buildArgs = ["build", "--bin", baseName];
     if (PROFILE === "release") buildArgs.push("--release");
-    if (TARGET !== "unknown" && TARGET !== HOST_TARGET) {
+    if (TARGET !== "unknown" && (process.env.TARGET || TARGET !== HOST_TARGET)) {
       buildArgs.push("--target", TARGET);
     }
 


### PR DESCRIPTION
## Which issue does this PR fix?

No linked issue.

This fixes a sidecar lookup edge case in `copy-proxy-binary.mjs`: when `TARGET` is explicitly set and equals the host Rust target, the script previously still used `src-tauri/target/{debug,release}`. Release workflows often build sidecars with an explicit `--target`, which writes them to `src-tauri/target/${TARGET}/{debug,release}` instead.

On Apple Silicon runners this matters for `TARGET=aarch64-apple-darwin`, because the explicit target can be the same as the host target. Without this change, a prebuilt sidecar in `target/aarch64-apple-darwin/release` can be missed, and `beforeBuildCommand` may rebuild `donut-proxy` / `donut-daemon` even though the target-specific artifacts already exist.

Benefits:

- Reuses the sidecar artifacts produced by the explicit Rust target build.
- Avoids unnecessary sidecar rebuilds in Tauri `beforeBuildCommand`.
- Reduces release latency on Apple Silicon self-hosted runners.
- Keeps default host builds unchanged when `TARGET` is not explicitly set.

## How to test

- `node --check src-tauri/copy-proxy-binary.mjs`
- Verified with a temporary fixture that `PROFILE=release TARGET=aarch64-apple-darwin node src-tauri/copy-proxy-binary.mjs` copies from `target/aarch64-apple-darwin/release` when those sidecar binaries already exist.
- Verified with fake `rustc` / `cargo` fixture that a missing explicit host-target sidecar is built with `--target aarch64-apple-darwin` and then copied from `target/aarch64-apple-darwin/release`.

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/zhom/donutbrowser/blob/main/CONTRIBUTING.md)
- [ ] Ran `pnpm format && pnpm lint && pnpm test` locally and it passes
- [ ] I tested the changes myself by running the app locally
- [x] Updated translations in all locale files (if UI text changed; no UI text changed)

## AI usage

- [x] I used AI to help write this PR

AI was used to identify the release-build sidecar lookup issue and draft the focused fix.
