### PR TITLE
fix: stop exporting deep-link URL handler

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -196,7 +196,6 @@ impl<R: Runtime> WindowExt for WebviewWindow<R> {
   }
 }
 
-#[tauri::command]
 async fn handle_url_open(app: tauri::AppHandle, url: String) -> Result<(), String> {
   log::info!("handle_url_open called with URL: {url}");
 
@@ -2216,7 +2215,6 @@ pub fn run() {
       disconnect_vpn,
       get_vpn_status,
       list_active_vpn_connections,
-      handle_url_open,
       // Cloud auth commands
       cloud_auth::cloud_exchange_device_code,
       cloud_auth::cloud_get_user,


### PR DESCRIPTION
## Which issue does this PR fix?

No existing issue.

Refs #389. That PR moved the cloud login device-link URL to `openUrl(...)` so it opens in the user's system browser instead of being routed through Donut's profile selector. After that flow no longer needs the profile-selector path, `handle_url_open` should remain an internal deep-link/startup URL helper only, not a frontend-invokable Tauri command.

This also fixes the Rust CI failure reported by `test_no_unused_tauri_commands`, where `handle_url_open` was exported in `generate_handler!` but had no frontend `invoke(...)` caller.

## How to test

1. Run `pnpm format && pnpm lint && pnpm test`.
2. Confirm `test_no_unused_tauri_commands` passes and reports all exported Tauri commands are used.
3. Review `src-tauri/src/lib.rs` and confirm `handle_url_open` is still called from deep-link/startup URL handling, but is no longer exported through `tauri::generate_handler!`.

Local checks run:

- `cargo test tests::test_no_unused_tauri_commands -- --nocapture`
- `pnpm format && pnpm lint && pnpm test`

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/zhom/donutbrowser/blob/main/CONTRIBUTING.md)
- [x] Ran `pnpm format && pnpm lint && pnpm test` locally and it passes
- [x] I tested the changes myself by running the app locally
- [x] Updated translations in all locale files (if UI text changed; no UI text changed)

## AI usage

- [x] I used AI to help write this PR

AI helped inspect the failing PR CI logs, relate the failure to #389, and prepare the minimal Rust cleanup. The final diff and checks were reviewed locally.
