### PR TITLE
ci: speed sidecar builds and harden token use

### DIFF
--- a/.github/workflows/issue-compliance.yml
+++ b/.github/workflows/issue-compliance.yml
@@ -75,8 +75,13 @@ jobs:
               response_format: { type: "json_object" }
             }')
 
+          umask 077
+          CURL_AUTH_CONFIG="$(mktemp)"
+          trap 'rm -f "$CURL_AUTH_CONFIG"' EXIT
+          printf 'header = "Authorization: Bearer %s"\n' "$OPENROUTER_API_KEY" > "$CURL_AUTH_CONFIG"
+
           RESPONSE=$(curl -fsSL https://openrouter.ai/api/v1/chat/completions \
-            -H "Authorization: Bearer $OPENROUTER_API_KEY" \
+            --config "$CURL_AUTH_CONFIG" \
             -H "Content-Type: application/json" \
             -d "$PAYLOAD")
 
@@ -203,8 +208,13 @@ jobs:
               response_format: { type: "json_object" }
             }')
 
+          umask 077
+          CURL_AUTH_CONFIG="$(mktemp)"
+          trap 'rm -f "$CURL_AUTH_CONFIG"' EXIT
+          printf 'header = "Authorization: Bearer %s"\n' "$OPENROUTER_API_KEY" > "$CURL_AUTH_CONFIG"
+
           RESPONSE=$(curl -fsSL https://openrouter.ai/api/v1/chat/completions \
-            -H "Authorization: Bearer $OPENROUTER_API_KEY" \
+            --config "$CURL_AUTH_CONFIG" \
             -H "Content-Type: application/json" \
             -d "$PAYLOAD")
 

--- a/.github/workflows/issue-validation.yml
+++ b/.github/workflows/issue-validation.yml
@@ -258,8 +258,13 @@ jobs:
               ]
             }')
 
+          umask 077
+          CURL_AUTH_CONFIG="$(mktemp)"
+          trap 'rm -f "$CURL_AUTH_CONFIG"' EXIT
+          printf 'header = "Authorization: Bearer %s"\n' "$OPENROUTER_API_KEY" > "$CURL_AUTH_CONFIG"
+
           RESPONSE=$(curl -fsSL https://openrouter.ai/api/v1/chat/completions \
-            -H "Authorization: Bearer $OPENROUTER_API_KEY" \
+            --config "$CURL_AUTH_CONFIG" \
             -H "Content-Type: application/json" \
             -d "$PAYLOAD")
 
@@ -431,8 +436,13 @@ jobs:
               ]
             }')
 
+          umask 077
+          CURL_AUTH_CONFIG="$(mktemp)"
+          trap 'rm -f "$CURL_AUTH_CONFIG"' EXIT
+          printf 'header = "Authorization: Bearer %s"\n' "$OPENROUTER_API_KEY" > "$CURL_AUTH_CONFIG"
+
           RESPONSE=$(curl -fsSL https://openrouter.ai/api/v1/chat/completions \
-            -H "Authorization: Bearer $OPENROUTER_API_KEY" \
+            --config "$CURL_AUTH_CONFIG" \
             -H "Content-Type: application/json" \
             -d "$PAYLOAD")
 
@@ -585,8 +595,13 @@ jobs:
               ]
             }')
 
+          umask 077
+          CURL_AUTH_CONFIG="$(mktemp)"
+          trap 'rm -f "$CURL_AUTH_CONFIG"' EXIT
+          printf 'header = "Authorization: Bearer %s"\n' "$OPENROUTER_API_KEY" > "$CURL_AUTH_CONFIG"
+
           RESPONSE=$(curl -fsSL https://openrouter.ai/api/v1/chat/completions \
-            -H "Authorization: Bearer $OPENROUTER_API_KEY" \
+            --config "$CURL_AUTH_CONFIG" \
             -H "Content-Type: application/json" \
             -d "$PAYLOAD")
 

--- a/.github/workflows/lint-rs.yml
+++ b/.github/workflows/lint-rs.yml
@@ -87,8 +87,7 @@ jobs:
         shell: bash
         working-directory: ./src-tauri
         run: |
-          cargo build --bin donut-proxy --release
-          cargo build --bin donut-daemon --release
+          cargo build --bin donut-proxy --bin donut-daemon --release
 
       - name: Copy sidecar binaries to Tauri binaries
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,8 +161,7 @@ jobs:
         shell: bash
         working-directory: ./src-tauri
         run: |
-          cargo build --bin donut-proxy --target ${{ matrix.target }} --release
-          cargo build --bin donut-daemon --target ${{ matrix.target }} --release
+          cargo build --bin donut-proxy --bin donut-daemon --target ${{ matrix.target }} --release
 
       - name: Copy sidecar binaries to Tauri binaries
         shell: bash

--- a/.github/workflows/rolling-release.yml
+++ b/.github/workflows/rolling-release.yml
@@ -160,8 +160,7 @@ jobs:
         shell: bash
         working-directory: ./src-tauri
         run: |
-          cargo build --bin donut-proxy --target ${{ matrix.target }} --release
-          cargo build --bin donut-daemon --target ${{ matrix.target }} --release
+          cargo build --bin donut-proxy --bin donut-daemon --target ${{ matrix.target }} --release
 
       - name: Copy sidecar binaries to Tauri binaries
         shell: bash


### PR DESCRIPTION
## Which issue does this PR fix?

None.

## How to test

- `go run github.com/rhysd/actionlint/cmd/actionlint@latest -shellcheck= -pyflakes= .github/workflows/*.yml`
- `pnpm format`
- `pnpm lint`
- `pnpm test` currently fails on upstream `main` with the existing unused `handle_url_open` Tauri command. I kept that out of this PR because it is covered separately in #397.

This changes the sidecar build steps to compile `donut-proxy` and `donut-daemon` in a single Cargo invocation. That avoids a second Cargo startup/metadata pass and lets Cargo plan both binaries together while preserving the same release profile and target triples. The benefit applies to the reusable Rust lint job and to every release target, including the Apple Silicon `aarch64-apple-darwin` release job where Rust sidecar builds are part of the critical path.

This also hardens the OpenRouter calls in the issue automation workflows. The bearer token is no longer expanded into the `curl` process arguments; each step writes a 0600 temporary curl config file and removes it with an EXIT trap. That reduces accidental token exposure through process argv on shared or self-hosted runners while preserving the existing API request behavior.

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/zhom/donutbrowser/blob/main/CONTRIBUTING.md)
- [ ] Ran `pnpm format && pnpm lint && pnpm test` locally and it passes
- [ ] I tested the changes myself by running the app locally
- [x] Updated translations in all locale files (if UI text changed)

## AI usage

- [x] I used AI to help write this PR

AI was used to identify the minimal workflow changes, implement them, and run local validation.