### PR TITLE
fix(sync): unseal encrypted metadata when downloading missing profiles

### DIFF
--- a/src-tauri/src/sync/engine.rs
+++ b/src-tauri/src/sync/engine.rs
@@ -2341,7 +2341,13 @@ impl SyncEngine {
     }
 
     let metadata_presign = self.client.presign_download(&metadata_key).await?;
-    let metadata_data = self.client.download_bytes(&metadata_presign.url).await?;
+    let metadata_raw = self.client.download_bytes(&metadata_presign.url).await?;
+    let metadata_data = encryption::maybe_unseal_after_download(&metadata_raw).map_err(|e| {
+      if e.contains("ENCRYPTION_PASSWORD_REQUIRED") {
+        let _ = events::emit("profile-sync-e2e-password-required", ());
+      }
+      SyncError::InvalidData(format!("Failed to unseal profile metadata: {e}"))
+    })?;
     let mut profile: BrowserProfile = serde_json::from_slice(&metadata_data)
       .map_err(|e| SyncError::SerializationError(format!("Failed to parse metadata: {e}")))?;
 
@@ -2756,7 +2762,11 @@ impl SyncEngine {
           Ok(stat) if stat.exists => match self.client.presign_download(&metadata_key).await {
             Ok(presign) => match self.client.download_bytes(&presign.url).await {
               Ok(data) => {
-                if let Ok(mut remote_profile) = serde_json::from_slice::<BrowserProfile>(&data) {
+                let unsealed = encryption::maybe_unseal_after_download(&data).ok();
+                let parsed = unsealed
+                  .as_ref()
+                  .and_then(|bytes| serde_json::from_slice::<BrowserProfile>(bytes).ok());
+                if let Some(mut remote_profile) = parsed {
                   remote_profile.sync_mode = *sync_mode;
                   remote_profile.last_sync = Some(
                     std::time::SystemTime::now()
@@ -4021,6 +4031,12 @@ pub async fn rollover_encryption_for_all_entities(
         }
       }
     });
+  }
+
+  if let Ok(engine) = SyncEngine::create_from_settings(&app_handle).await {
+    if let Err(e) = engine.check_for_missing_synced_profiles(&app_handle).await {
+      log::warn!("Rollover: failed to check for missing profiles: {e}");
+    }
   }
 
   let _ = events::emit("e2e-rollover-completed", ());


### PR DESCRIPTION
## Summary

Fixes #466

When E2E encryption is enabled, `download_profile_if_missing` parsed `metadata.json` as plaintext JSON even though uploads seal it via `maybe_seal_for_upload`. Encrypted profiles therefore never appeared on other devices despite the correct password.

This PR aligns the missing-profile download path with other sync download paths by unsealing metadata before JSON parsing.

## Changes

- **`download_profile_if_missing`**: call `maybe_unseal_after_download` on downloaded metadata; emit `profile-sync-e2e-password-required` when the E2E password is missing
- **Cross-OS metadata refresh**: unseal metadata before parsing during sync
- **`rollover_encryption_for_all_entities`**: re-run `check_for_missing_synced_profiles` after rollover so profiles that failed to download before rollover are discovered

## Test plan

- [ ] Enable E2E sync password on device A, create a profile, sync
- [ ] On device B with the same E2E password, trigger sync — profile should appear
- [ ] Cross-OS profile metadata refresh works with E2E encryption enabled
- [ ] After E2E password rollover, missing profiles are re-discovered automatically

