### PR TITLE
fix(profiles): sync running state when browser closes outside Donut

### DIFF
--- a/src-tauri/src/events/mod.rs
+++ b/src-tauri/src/events/mod.rs
@@ -77,6 +77,23 @@ pub fn emit_empty(event: &str) -> Result<(), String> {
   global_emitter().emit_value(event, serde_json::Value::Null)
 }
 
+#[derive(Serialize)]
+struct ProfileRunningChangedPayload {
+  id: String,
+  is_running: bool,
+}
+
+/// Notify the frontend that a profile's browser running state changed.
+pub fn emit_profile_running_changed(profile_id: &str, is_running: bool) -> Result<(), String> {
+  emit(
+    "profile-running-changed",
+    ProfileRunningChangedPayload {
+      id: profile_id.to_string(),
+      is_running,
+    },
+  )
+}
+
 #[cfg(test)]
 mod tests {
   use super::*;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1992,6 +1992,7 @@ pub fn run() {
             .collect();
 
           for profile in profiles_to_check {
+            let had_pid = profile.process_id.is_some();
             // Check browser status and track changes
             match runner
               .check_browser_status(app_handle_status.clone(), &profile)
@@ -2004,8 +2005,14 @@ pub fn run() {
                   .copied()
                   .unwrap_or(false);
 
-                // Only emit event if state actually changed
-                if last_state != is_running {
+                // Emit when the running state changed, or when we still had a
+                // stored PID but the browser is gone — the launch path sets the
+                // frontend to "running" immediately, and a missed transition
+                // here leaves the stop button stuck.
+                let should_emit =
+                  last_state != is_running || (!is_running && had_pid);
+
+                if should_emit {
                   log::debug!(
                     "Status checker detected change for profile {}: {} -> {}",
                     profile.name,

--- a/src-tauri/src/profile/manager.rs
+++ b/src-tauri/src/profile/manager.rs
@@ -1438,6 +1438,32 @@ impl ProfileManager {
     Ok(profile)
   }
 
+  /// Clear a stored browser PID and notify the frontend the profile stopped.
+  fn finalize_profile_stopped(&self, app_handle: &tauri::AppHandle, latest: &mut BrowserProfile) {
+    if latest.process_id.is_none() {
+      return;
+    }
+
+    let profile_id = latest.id.to_string();
+    latest.process_id = None;
+    if let Err(e) = self.save_profile(latest) {
+      log::warn!("Warning: Failed to clear profile PID: {e}");
+    }
+
+    if let Some(updated) = crate::auto_updater::AutoUpdater::instance()
+      .update_profile_to_latest_installed(app_handle, latest)
+    {
+      *latest = updated;
+    }
+
+    if let Err(e) = events::emit("profile-updated", latest) {
+      log::warn!("Warning: Failed to emit profile update event: {e}");
+    }
+    if let Err(e) = events::emit_profile_running_changed(&profile_id, false) {
+      log::warn!("Failed to emit profile-running-changed event: {e}");
+    }
+  }
+
   pub async fn check_browser_status(
     &self,
     app_handle: tauri::AppHandle,
@@ -1581,7 +1607,6 @@ impl ProfileManager {
           }
         }
       } else if merged.process_id.is_some() {
-        // Clear the PID if no process found
         merged.process_id = None;
         if let Err(e) = self.save_profile(&merged) {
           log::warn!("Warning: Failed to clear profile PID: {e}");
@@ -1594,6 +1619,9 @@ impl ProfileManager {
           .update_profile_to_latest_installed(&app_handle, &merged)
         {
           merged = updated;
+        }
+        if let Err(e) = events::emit_profile_running_changed(&merged.id.to_string(), false) {
+          log::warn!("Failed to emit profile-running-changed event: {e}");
         }
       }
 
@@ -1682,20 +1710,7 @@ impl ProfileManager {
           };
 
           if latest.process_id.is_some() {
-            latest.process_id = None;
-            if let Err(e) = self.save_profile(&latest) {
-              log::warn!("Warning: Failed to clear Camoufox profile process info: {e}");
-            }
-
-            if let Some(updated) = crate::auto_updater::AutoUpdater::instance()
-              .update_profile_to_latest_installed(app_handle, &latest)
-            {
-              latest = updated;
-            }
-
-            if let Err(e) = events::emit("profile-updated", &latest) {
-              log::warn!("Warning: Failed to emit profile update event: {e}");
-            }
+            self.finalize_profile_stopped(app_handle, &mut latest);
           }
         }
         Ok(false)
@@ -1722,23 +1737,7 @@ impl ProfileManager {
           };
 
           if latest.process_id.is_some() {
-            latest.process_id = None;
-            if let Err(e2) = self.save_profile(&latest) {
-              log::warn!(
-                "Warning: Failed to clear Camoufox profile process info after error: {e2}"
-              );
-            }
-
-            if let Some(updated) = crate::auto_updater::AutoUpdater::instance()
-              .update_profile_to_latest_installed(app_handle, &latest)
-            {
-              latest = updated;
-            }
-
-            // Emit profile update event to frontend
-            if let Err(e3) = events::emit("profile-updated", &latest) {
-              log::warn!("Warning: Failed to emit profile update event: {e3}");
-            }
+            self.finalize_profile_stopped(app_handle, &mut latest);
           }
         }
         Ok(false)
@@ -1787,9 +1786,14 @@ impl ProfileManager {
               let _ = crate::proxy_manager::PROXY_MANAGER.update_proxy_pid(prev, new);
             }
 
-            // Emit profile update event to frontend
             if let Err(e) = events::emit("profile-updated", &latest) {
               log::warn!("Warning: Failed to emit profile update event: {e}");
+            }
+
+            if old_pid.is_none() && wayfern_process.processId.is_some() {
+              if let Err(e) = events::emit_profile_running_changed(&latest.id.to_string(), true) {
+                log::warn!("Failed to emit profile-running-changed event: {e}");
+              }
             }
 
             log::info!(
@@ -1822,20 +1826,7 @@ impl ProfileManager {
           };
 
           if latest.process_id.is_some() {
-            latest.process_id = None;
-            if let Err(e) = self.save_profile(&latest) {
-              log::warn!("Warning: Failed to clear Wayfern profile process info: {e}");
-            }
-
-            if let Some(updated) = crate::auto_updater::AutoUpdater::instance()
-              .update_profile_to_latest_installed(app_handle, &latest)
-            {
-              latest = updated;
-            }
-
-            if let Err(e) = events::emit("profile-updated", &latest) {
-              log::warn!("Warning: Failed to emit profile update event: {e}");
-            }
+            self.finalize_profile_stopped(app_handle, &mut latest);
           }
         }
         Ok(false)


### PR DESCRIPTION
## Summary

When a user closes Chromium via the window close button (bypassing Donut's Stop action), the profile row could stay on the Stop icon even though the browser process had exited. This fix ensures the frontend receives `profile-running-changed` events when the periodic status checker detects a natural browser exit and when stored PIDs are cleared.

## Changes

- `src-tauri/src/events/mod.rs`: add `emit_profile_running_changed` helper for consistent UI notifications.
- `src-tauri/src/lib.rs`: status checker also emits when a profile still had a stored PID but is no longer running (covers missed transitions).
- `src-tauri/src/profile/manager.rs`: centralize stop bookkeeping in `finalize_profile_stopped`, emit stop events when clearing PIDs, and re-emit running when a Wayfern process is rediscovered after a false negative.

## Test plan

- [ ] Launch a Wayfern profile; confirm the row shows Stop.
- [ ] Close Chromium with the window X button; within ~5s the row should show Play/Launch again.
- [ ] Launch again and use Donut's Stop button; row should return to Play immediately.
- [ ] `cd src-tauri && cargo test --lib` passes.

Fixes #472
