### PR TITLE
fix: open profiles maximized on primary screen

### DIFF
--- a/src-tauri/src/browser.rs
+++ b/src-tauri/src/browser.rs
@@ -693,6 +693,9 @@ impl Browser for WayfernBrowser {
       "--disable-features=DialMediaRouteProvider".to_string(),
       "--use-mock-keychain".to_string(),
       "--password-store=basic".to_string(),
+      // Window position and size - open maximized on primary screen
+      "--start-maximized".to_string(),
+      "--window-position=0,0".to_string(),
     ];
 
     // Add remote debugging port (required for CDP fingerprint injection)


### PR DESCRIPTION
## Problem
When launching a Wayfern browser profile, the window was not opening correctly on the screen — it would appear in wrong position or with incorrect size instead of fitting the primary monitor properly.

## Solution
Added two Chromium launch flags in `src-tauri/src/browser.rs` inside `WayfernBrowser::create_launch_args()`:

- `--start-maximized` — opens the profile window maximized on the primary screen
- `--window-position=0,0` — ensures window starts from top-left corner of the primary monitor

No existing lines were removed or replaced. Only 2 new args were added to the existing launch args vector.